### PR TITLE
Make Vagrant tag support act like RightScale

### DIFF
--- a/libraries/machine_tag_vagrant.rb
+++ b/libraries/machine_tag_vagrant.rb
@@ -35,7 +35,7 @@ class Chef
     def create(tag)
       update_tag_file do |tag_array|
         old_tags = ::MachineTag::Set.new(tag_array)[::MachineTag::Tag.new(tag).namespace_and_predicate]
-        tag_array.delete(old_tags.first) unless old_tags.empty?
+        old_tags.each { |old_tag| tag_array.delete(old_tag) }
         tag_array << tag unless tag_array.include?(tag)
       end
     end


### PR DESCRIPTION
- Replace machine tags with the same namespace and predicate when adding
  new ones.
