### PR TITLE
pinning gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,8 @@ group :integration do
   gem 'travis-lint'
   gem 'chefspec', '~> 2.0.1'
   gem 'strainer', '~> 3.3.0'
+  gem 'buff-ignore','1.1.1'
+  gem 'rack', '1.6.4'
+  gem 'json','~> 1.8.0'
+  gem 'net-http-persistent', '= 2.9.4'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Installs/Configures machine_tag'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'
 
-depends 'apt', '~> 2.9.2'
-depends 'build-essential'
+depends 'apt', '~> 3.0.0'
+depends 'build-essential','~> 3.2.0'
 
 recipe 'machine_tag::default', "Installs the 'machine_tag' gem used by the helpers."

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,4 +21,7 @@ log "Installing 'machine_tag' gem"
 include_recipe 'build-essential'
 
 chef_gem 'machine_tag'
-chef_gem 'right_api_client'
+# pin gem for ruby 1.9/chef 11 compatiblity
+chef_gem 'right_api_client' do
+  version "1.6.1"
+end


### PR DESCRIPTION
chef 11 only supports ruby 1.9.3 and right_api_client now only support ruby => 2.0.
pinning right_api_client at 1.6.1 until chef 12 is supported.
pinning other gems for ruby 1.9 compatiblity